### PR TITLE
fix: npm-based Claude Code install, GCM v2.7.3, fix apt -y

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -73,8 +73,9 @@ RUN cd /usr/local/bin/ && \
 # Install GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/trusted.gpg.d/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
-    apt update && \
-    apt install gh
+    apt-get update && \
+    apt-get install -y gh && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/log/supervisor && \
     touch /var/log/supervisor/supervisord.log && \
@@ -84,14 +85,21 @@ RUN setcap 'cap_net_bind_service=+ep' /usr/bin/supervisord
 
 RUN echo 'export PS1="[\u@cyverse] \w $ "' >> /home/rstudio/.bashrc
 
+# Install git-credential-manager
+ARG GCM_VERSION="2.7.3"
+RUN wget https://github.com/git-ecosystem/git-credential-manager/releases/download/v${GCM_VERSION}/gcm-linux-x64-${GCM_VERSION}.deb \
+        -O /tmp/gcm.deb && \
+    dpkg -i /tmp/gcm.deb && \
+    rm /tmp/gcm.deb && \
+    echo "Git Credential Manager ${GCM_VERSION} installed"
+ENV GCM_CREDENTIAL_STORE=cache
+
 # Install AI tools (Claude Code, Gemini CLI, OpenAI Codex)
 USER rstudio
-# Install Claude Code using official installer
-RUN curl -fsSL https://claude.ai/install.sh | bash
-# Install Gemini CLI and OpenAI Codex via npm
 RUN npm config set prefix /home/rstudio/.npm-global && \
     export PATH=/home/rstudio/.npm-global/bin:$PATH && \
-    npm install -g @google/gemini-cli @openai/codex
+    npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
+    npm cache clean --force
 ENV PATH="/home/rstudio/.npm-global/bin:${PATH}"
 USER root
 


### PR DESCRIPTION
## Summary
- Replace fragile curl-pipe-bash Claude Code installer with `npm install -g @anthropic-ai/claude-code` (all three AI tools in a single RUN layer)
- Add Git Credential Manager v2.7.3 installation (was missing from this image)
- Fix `apt install gh` missing `-y` flag (would hang non-interactively)
- Add `apt-get clean` to GitHub CLI install step

## Test plan
- [ ] Build Docker image locally: `docker build -t rstudio-verse:test latest/`
- [ ] Verify `claude` CLI is available as rstudio user
- [ ] Verify `gemini` and `codex` CLIs are available
- [ ] Verify `git-credential-manager` is installed
- [ ] Verify `gh` CLI is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)