### PR TITLE
fix: add OpenCode, fix PATH for AI CLIs

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -97,10 +97,13 @@ ENV GCM_CREDENTIAL_STORE=cache
 # Install AI tools (Claude Code, Gemini CLI, OpenAI Codex)
 USER rstudio
 RUN npm config set prefix /home/rstudio/.npm-global && \
-    export PATH=/home/rstudio/.npm-global/bin:$PATH && \
     npm install -g @anthropic-ai/claude-code @google/gemini-cli @openai/codex && \
     npm cache clean --force
-ENV PATH="/home/rstudio/.npm-global/bin:${PATH}"
+
+# Install OpenCode (https://opencode.ai/)
+RUN curl -fsSL https://opencode.ai/install | bash
+
+ENV PATH="/home/rstudio/.npm-global/bin:/home/rstudio/.opencode/bin:${PATH}"
 USER root
 
 WORKDIR /home/rstudio/data-store


### PR DESCRIPTION
## Problem
- OpenCode was missing from this container
- ENV PATH did not include OpenCode's install directory

## Changes
- Add OpenCode install via `curl -fsSL https://opencode.ai/install | bash`
- Add `/home/rstudio/.opencode/bin` to ENV PATH

## Tools available after this fix
- ✅ `claude` — Claude Code
- ✅ `gemini` — Gemini CLI  
- ✅ `codex` — OpenAI Codex
- ✅ `opencode` — Open Code

Users provide their own API keys / login to their accounts.