### PR TITLE
fix: add --no-modify-path to opencode install (prevent Docker build hang)

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -101,7 +101,7 @@ RUN npm config set prefix /home/rstudio/.npm-global && \
     npm cache clean --force
 
 # Install OpenCode (https://opencode.ai/)
-RUN curl -fsSL https://opencode.ai/install | bash
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path
 
 ENV PATH="/home/rstudio/.npm-global/bin:/home/rstudio/.opencode/bin:${PATH}"
 USER root


### PR DESCRIPTION
fix: add --no-modify-path to opencode install

The opencode installer tries to detect the current shell and modify config files (.bashrc, .zshrc, etc.). In a Docker build context this can hang indefinitely since there's no interactive shell to detect.

Adding `--no-modify-path` skips that step entirely — PATH is already set via the ENV instruction.